### PR TITLE
Added 'create' serialization group for token on PaymentSource

### DIFF
--- a/src/Traits/PaymentSourceTrait.php
+++ b/src/Traits/PaymentSourceTrait.php
@@ -48,6 +48,9 @@ trait PaymentSourceTrait
 
     /**
      * Payment source token.
+     * Serialization group 'create' required for FeeRepository compatibility
+     *
+     * @Groups({"create"})
      *
      * @var string|null
      */


### PR DESCRIPTION
This will allow the FeeCalculator repository to once again work when an endpoint token is present