### PR TITLE
PYMT-1594 Add cvc to credit card payment source.

### DIFF
--- a/src/Endpoints/PaymentSources/CreditCard.php
+++ b/src/Endpoints/PaymentSources/CreditCard.php
@@ -8,6 +8,7 @@ use EoneoPay\PhpSdk\Traits\PaymentSources\CreditCardTrait;
 
 /**
  * @method mixed[]|null getBin()
+ * @method string|null getCvc()
  * @method mixed[]|null getExpiry()
  * @method string|null getFacility()
  */

--- a/src/Traits/PaymentSourceTrait.php
+++ b/src/Traits/PaymentSourceTrait.php
@@ -49,6 +49,8 @@ trait PaymentSourceTrait
     /**
      * Payment source token.
      *
+     * @Groups({"create"})
+     *
      * @var string|null
      */
     protected $token;

--- a/src/Traits/PaymentSourceTrait.php
+++ b/src/Traits/PaymentSourceTrait.php
@@ -52,8 +52,6 @@ trait PaymentSourceTrait
      *
      * @Groups({"create"})
      *
-     * @Groups({"create"})
-     *
      * @var string|null
      */
     protected $token;

--- a/src/Traits/PaymentSources/CreditCardTrait.php
+++ b/src/Traits/PaymentSources/CreditCardTrait.php
@@ -17,6 +17,15 @@ trait CreditCardTrait
     protected $bin;
 
     /**
+     * Credit card cvc.
+     *
+     * @Groups({"create"})
+     *
+     * @var string|null
+     */
+    protected $cvc;
+
+    /**
      * Expiry month and year.
      *
      * @Groups({"create"})

--- a/tests/Endpoints/PaymentSources/CreditCardTest.php
+++ b/tests/Endpoints/PaymentSources/CreditCardTest.php
@@ -60,6 +60,7 @@ final class CreditCardTest extends TestCase
             ]
         )->create('4UM78RDZW93B84UJ', $creditCard);
 
+        self::assertSame('123', $creditCard->getCvc());
         self::assertInstanceOf(CreditCard::class, $actual);
 
         /**

--- a/tests/Endpoints/PaymentSources/CreditCardTest.php
+++ b/tests/Endpoints/PaymentSources/CreditCardTest.php
@@ -22,6 +22,7 @@ final class CreditCardTest extends TestCase
     {
         $creditCard = new CreditCard(
             [
+                'cvc' => '123',
                 'expiry' => [
                     'month' => '11',
                     'year' => '2099',

--- a/tests/Endpoints/Transactions/PrimaryTransactionsTest.php
+++ b/tests/Endpoints/Transactions/PrimaryTransactionsTest.php
@@ -72,7 +72,10 @@ final class PrimaryTransactionsTest extends TransactionTestCase
 
         $expected = new Transaction(\array_merge($data, [
             'amount' => new Amount($data['amount']),
-            'paymentSource' => new CreditCard($data['paymentSource']),
+            'paymentSource' => new CreditCard(\array_merge(
+                $data['paymentSource'],
+                ['cvc' => '123']
+            )),
         ]));
 
         $actual = $this->createApiManager($this->createResponse($data))

--- a/tests/Endpoints/Users/EwalletFundingTest.php
+++ b/tests/Endpoints/Users/EwalletFundingTest.php
@@ -46,11 +46,14 @@ class EwalletFundingTest extends ValidationEnabledTestCase
      */
     public function testCreateEwalletFunding(): void
     {
-        $fundingSource = new CreditCard();
-        $ewallet = new Ewallet();
+        $fundingSource = new CreditCard([
+            'cvc' => '123',
+            'token' => 'BBEJ6JGRHAZ2KUBD89C3'
+        ]);
+        $ewallet = new Ewallet(['currency' => 'AUD', 'reference' => 'YNGANFK8Y7']);
         $class = new EwalletFunding([
             'ewallet' => $ewallet,
-            'primaryEndpoint' => $fundingSource,
+            'fundingSource' => $fundingSource,
             'id' => 'FUNDING_ID',
             'targetAmount' => '100.00',
             'threshold' => '20.00',


### PR DESCRIPTION
Add cvc to credit card payment source so that it can be sent when performing transaction.

Ticket: [https://eonx.atlassian.net/browse/PYMT-1594](https://eonx.atlassian.net/browse/PYMT-1594)